### PR TITLE
Include variable for erlang version

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,7 +18,7 @@
     update_cache=yes
     state=present
   with_items:
-    - esl-erlang
+    - esl-erlang="{{ esl_erlang_version }}"
     - elixir
     - inotify-tools
 - command: mix local.hex --force

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,7 +19,7 @@
     state=present
   with_items:
     - esl-erlang="{{ esl_erlang_version }}"
-    - elixir
+    - elixir="{{ elixir_version }}"
     - inotify-tools
 - command: mix local.hex --force
   sudo: yes

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,11 +1,3 @@
 ---
 git_clone_path: /opt/tinker/shared_files/elixir
-phoenix_commands:
-  - "mix deps.get"
-  - "mix ecto.create --force"
-  - "mix ecto.migrate --force"
-production_commands:
-  - "mix deps.get --only prod"
-  - "MIX_ENV=prod mix compile"
-  - "MIX_ENV=prod mix ecto.migrate"
-#http://www.phoenixframework.org/docs/deployment
+esl_erlang_version: 1:19.0.3

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 git_clone_path: /opt/tinker/shared_files/elixir
 esl_erlang_version: 1:19.0.3
+elixir_version: 1.3.2-1


### PR DESCRIPTION
Latest erlang version (1:19.1) causes an error: `error while loading shared libraries: libsctp.so.1:` while compiling. 

Now we can specify esl-erlang version to be stable. 
